### PR TITLE
hotfix:[김호유] 로고 클릭시 메인페이지로 돌아가는UI [WMC-UI 5] 

### DIFF
--- a/frontend/src/components/main/layoutForm/navigation/NavigationMenuPage.vue
+++ b/frontend/src/components/main/layoutForm/navigation/NavigationMenuPage.vue
@@ -2,9 +2,10 @@
     <nav>
       <v-app-bar color="white" class="flex-grow-0" app>
         <v-app-bar-nav-icon @click="navigation_drawer = !navigation_drawer"/>
-        <a href="'http://localhost:8080/#/'">
-        <v-img class="mx-2" src="@/assets/logo.png" max-height="40" max-width="40" contain/>
-        </a>
+        <router-link to="/">
+          <v-img
+              :src="require('@/assets/logo.png')" max-height="40" max-width="40" class="mx2"/>
+        </router-link>
         <v-toolbar-title class="text-uppercase text--darken-4">
           <span>WMC</span>
         </v-toolbar-title>


### PR DESCRIPTION
a태그 이용후 로고 클릭시 홈 링크로 들어가긴 하지만 url이 계속 추가되는 이슈 발생  /
이후 router-link 로 코드 변경후 이슈 해결.